### PR TITLE
Factor out getIxyt

### DIFF
--- a/quicknxs/qreduce.py
+++ b/quicknxs/qreduce.py
@@ -1288,6 +1288,7 @@ class LRDataset(object):
   incident_angle = 0
   
   nxs=None # Mantid NeXus workspace
+  nxs_histo=None # Mantid NeXus workspace, rebinned
 
   ai=None #: incident angle
   dpix=0 #: pixel of direct beam position at dangle0
@@ -1695,6 +1696,12 @@ class LRDataset(object):
     #output.Exyt_reduction = Exyt_reduction
     
     return output
+
+  def ixyIndex(self, x, y):
+    if self.new_detector_geometry_flag:
+      return 304 * x + y
+    else:
+      return 256 * x + y
 
   @staticmethod
   def getIxyt(nxs_histo, new_detector_flag):

--- a/quicknxs/qreduce.py
+++ b/quicknxs/qreduce.py
@@ -1623,44 +1623,34 @@ class LRDataset(object):
     output.proton_charge = _proton_charge * 3.6   # to go from microA/h to mC
     output.proton_charge_units = new_proton_charge_units
 
-    #if _proton_charge > 0:
-      #nxs_histo = NormaliseByCurrent(InputWorkspace=nxs_histo)
-    
-    # retrieve 3D array
-    [_tof_axis, Ixyt, Exyt] = LRDataset.getIxyt(nxs_histo, output.new_detector_geometry_flag)
-    output.tof_axis_auto_with_margin = _tof_axis
-    
+    output.tof_axis_auto_with_margin = nxs_histo.readX(0)
+
     ## keep only the low resolution range requested
-#    print read_options['low_res_range_flag']
     low_res_range = [int(read_options['low_res_range'][0]), int(read_options['low_res_range'][1])]
     from_pixel = min(low_res_range)
     to_pixel = max(low_res_range)
 
-    # keep only low resolution range defined
-    Ixyt = Ixyt[from_pixel:to_pixel,:,:]
-    Exyt = Exyt[from_pixel:to_pixel,:,:]
-    
-    output.Ixyt = Ixyt
-    output.Exyt = Exyt
-    
     # create projections for the 2D datasets
-    Ixy = Ixyt.sum(axis=2)
-    #axisToSum = 2
-    #[Ixy, Exy] = weighted_sum(Ixyt, Exyt, axisToSum)
-    
-    Iyt = Ixyt.sum(axis=0)
+    x_size = to_pixel - from_pixel
+    y_size = output.ixyIndex(1,0)
+    num_bins = nxs_histo.blocksize()
+
+    Iyt = np.zeros((y_size, num_bins))
+    for x in range(x_size):
+      for y in range(y_size):
+        Iyt[y] += nxs_histo.readY(output.ixyIndex(from_pixel + x,y))
     Iit = Iyt.sum(axis=0)
-    Iix = Ixy.sum(axis=1)
     Iyi = Iyt.sum(axis=1)
 
-    # store the data
-    #output.tof_edges=_tof_axis
-    #output.tof_edges_full = [tmin, tmax]
-    #output.tof_edges_auto = [autotmin, autotmax]
-    output.data=Ixyt.astype(float) # 3D dataset
-    output.xydata=Ixy.transpose().astype(float) # 2D dataset
-    output.ytofdata=Iyt.astype(float) # 2D dataset
+    Ixy = np.zeros((x_size,y_size))
+    for x in range(x_size):
+      for y in range(y_size):
+        Ixy[x,y] = np.sum(nxs_histo.readY(output.ixyIndex(from_pixel + x, y)))
+    Iix = Ixy.sum(axis=1)
 
+    # store the data
+    output.xydata = Ixy.transpose().astype(float)
+    output.ytofdata = Iyt.astype(float)
     output.countstofdata = Iit.astype(float)
     output.countsxdata = Iix.astype(float)
     output.ycountsdata = Iyi.astype(float)
@@ -1677,23 +1667,6 @@ class LRDataset(object):
       back1 = int(peak1 - backOffsetFromPeak)
       back2 = int(peak2 + backOffsetFromPeak)
       output.back = [str(back1), str(back2)]
-
-    ### work now with final data
-
-    ## rebin using final data reduction parameters
-    #params_reduction = [float(autotmin), float(tbin), float(autotmax)]
-    #nxs_histo_reduction = Rebin(InputWorkspace=nxs, Params=params_reduction, PreserveEvents=True)
-    ## normalize by proton charge
-    #nxs_histo_reduction = NormaliseByCurrent(InputWorkspace=nxs_histo_reduction)
-
-    ## retrieve 3D array
-    #[_tof_axis_reduction, Ixyt_reduction, Exyt_reduction] = LRDataset.getIxyt(nxs_histo_reduction)
-
-    #Ixyt_reduction = Ixyt_reduction[from_pixel:to_pixel,:,:]
-    #Exyt_reduction = Exyt_reduction[from_pixel:to_pixel,:,:]
-    
-    #output.Ixyt_reduction = Ixyt_reduction
-    #output.Exyt_reduction = Exyt_reduction
     
     return output
 

--- a/quicknxs/qreduce.py
+++ b/quicknxs/qreduce.py
@@ -1677,40 +1677,6 @@ class LRDataset(object):
       return 256 * x + y
 
   @staticmethod
-  def getIxyt(nxs_histo, new_detector_flag):
-    '''
-    will format the histogrma NeXus to retrieve the full 3D data set
-    '''
-    _tof_axis = nxs_histo.readX(0)[:].copy()
-    nbr_tof = len(_tof_axis)
-    
-    if new_detector_flag:
- 
-      sz_y_axis = 304
-      sz_x_axis = 256
-       
-    else:
-      
-      sz_y_axis = 256
-      sz_x_axis = 304
-
-    _y_axis = zeros((sz_x_axis, sz_y_axis, nbr_tof-1))
-    _y_error_axis = zeros((sz_x_axis, sz_y_axis, nbr_tof-1))
-  
-    x_range = range(sz_x_axis)
-    y_range = range(sz_y_axis)
-      
-    for x in x_range:
-      for y in y_range:
-        _index = int(sz_y_axis*x+y)
-        _tmp_data = nxs_histo.readY(_index)[:].copy()
-        _y_axis[x,y,:] = _tmp_data
-        _tmp_error = nxs_histo.readE(_index)[:].copy()
-        _y_error_axis[x,y,:] = _tmp_error
-
-    return [_tof_axis, _y_axis, _y_error_axis]    
-
-  @staticmethod
   def bin_events(tof_ids, tof_time, tof_edges,
                  callback=None, callback_offset=0., callback_scaling=1.):
     '''

--- a/quicknxs/reduction.py
+++ b/quicknxs/reduction.py
@@ -261,11 +261,7 @@ class ReductionObject(object):
         nxs_histo = NormaliseByCurrent(InputWorkspace=nxs_histo)
         data.nxs_histo = nxs_histo
 
-        [_tof_axis, Ixyt, Exyt] = LRDataset.getIxyt(nxs_histo, data.new_detector_geometry_flag)
-
-        data.tof_axis = _tof_axis
-        data.Ixyt = Ixyt
-        data.Exyt = Exyt
+        data.tof_axis = nxs_histo.readX(0)
         self.oData.active_data = data
 
         self.logbook('-> rebin DATA ... DONE')
@@ -281,11 +277,7 @@ class ReductionObject(object):
             norm_nxs_histo = NormaliseByCurrent(InputWorkspace=norm_nxs_histo)
             norm.nxs_histo = norm_nxs_histo
             
-            [_tof_axis, Ixyt, Exyt] = LRDataset.getIxyt(norm_nxs_histo, norm.new_detector_geometry_flag)
-            
-            norm.tof_axis = _tof_axis
-            norm.Ixyt = Ixyt
-            norm.Exyt = Exyt
+            norm.tof_axis = norm_nxs_histo.readX(0)
             self.oNorm.active_data = norm
             
             self.logbook('-> rebin NORMALIZATION ... DONE')

--- a/quicknxs/reduction.py
+++ b/quicknxs/reduction.py
@@ -259,6 +259,7 @@ class ReductionObject(object):
 
         nxs_histo = Rebin(InputWorkspace=nxs, Params=rebin_params, PreserveEvents=True)
         nxs_histo = NormaliseByCurrent(InputWorkspace=nxs_histo)
+        data.nxs_histo = nxs_histo
 
         [_tof_axis, Ixyt, Exyt] = LRDataset.getIxyt(nxs_histo, data.new_detector_geometry_flag)
 
@@ -278,6 +279,7 @@ class ReductionObject(object):
             
             norm_nxs_histo = Rebin(InputWorkspace=norm_nxs, Params=rebin_params, PreserveEvents=True)
             norm_nxs_histo = NormaliseByCurrent(InputWorkspace=norm_nxs_histo)
+            norm.nxs_histo = norm_nxs_histo
             
             [_tof_axis, Ixyt, Exyt] = LRDataset.getIxyt(norm_nxs_histo, norm.new_detector_geometry_flag)
             
@@ -590,32 +592,24 @@ class ReductionObject(object):
         self.logbook('--> from pixel: ' + str(from_pixel))
         self.logbook('--> to pixel: ' + str(to_pixel))
         
-#        print '-> from_pixel: %d' % from_pixel
-#        print '-> to_pixel: %d' % to_pixel
-
-        Ixyt = data.Ixyt   # for example [303,256,471]
-        Exyt = data.Exyt
-         
-#        x_dim = np.size(Ixyt,0)
-#        y_dim = np.size(Ixyt,1)
-#        tof_dim = np.size(Ixyt,2)
-        
-#        _y_error_axis = np.zeros((y_dim, tof_dim))
-        
-#        x_size = to_pixel - from_pixel + 1
-#        x_range = np.arange(x_size) + from_pixel
-        
-#        y_range = np.arange(y_dim)
-
         # calculate y axis
-        Ixyt_crop = Ixyt[from_pixel:to_pixel+1,:,:]
-        self.data_y_axis = Ixyt_crop.sum(axis=0)
+        nxs = data.nxs_histo
+        x_size = to_pixel - from_pixel
+        y_size = data.ixyIndex(1,0)
+        num_bins = nxs.blocksize()
+        new_data_y_axis = np.zeros((y_size, num_bins))
+        for y in range(y_size):
+            for x in range(x_size):
+                new_data_y_axis[y] += nxs.readY(data.ixyIndex(from_pixel + x,y))
+        self.data_y_axis = new_data_y_axis
         
         # calculate error axis
-        Exyt_crop = Exyt[from_pixel:to_pixel+1,:,:]
-        Exyt_crop_sq = Exyt_crop * Exyt_crop
-        _y_error_axis = Exyt_crop_sq.sum(axis=0)
-        self.data_y_error_axis = np.sqrt(_y_error_axis)
+        new_data_e_axis = np.zeros((y_size, num_bins))
+        for y in range(y_size):
+            for x in range(x_size):
+                    e = nxs.readE(data.ixyIndex(from_pixel + x,y))
+                    new_data_e_axis[y] += e * e
+        self.data_y_error_axis = np.sqrt(new_data_e_axis)
 
         # work with Normalization
         if self.oNorm is not None:
@@ -628,18 +622,24 @@ class ReductionObject(object):
                 from_pixel = int(norm.low_resolution_range[0])
                 to_pixel = int(norm.low_resolution_range[1])
         
-            Ixyt = norm.Ixyt   # for example [303,255,471]
-            Exyt = norm.Exyt
-        
             # calculate y axis
-            Ixyt_crop = Ixyt[from_pixel:to_pixel+1,:,:]
-            self.norm_y_axis = Ixyt_crop.sum(axis=0)
+            nxs = norm.nxs_histo
+            x_size = to_pixel - from_pixel
+            y_size = norm.ixyIndex(1,0)
+            num_bins = nxs.blocksize()
+            new_norm_y_axis = np.zeros((y_size, num_bins))
+            for y in range(y_size):
+                for x in range(x_size):
+                    new_norm_y_axis[y] += nxs.readY(norm.ixyIndex(from_pixel + x,y))
+            self.norm_y_axis = new_norm_y_axis
             
             # calculate error axis
-            Exyt_crop = Exyt[from_pixel:to_pixel+1,:,:]
-            Exyt_crop_sq = Exyt_crop * Exyt_crop
-            _y_error_axis = Exyt_crop_sq.sum(axis=0)
-            self.norm_y_error_axis = np.sqrt(_y_error_axis)
+            new_norm_e_axis = np.zeros((y_size, num_bins))
+            for y in range(y_size):
+                for x in range(x_size):
+                        e = nxs.readE(norm.ixyIndex(from_pixel + x,y))
+                        new_norm_e_axis[y] += e * e
+            self.norm_y_error_axis = np.sqrt(new_norm_e_axis)
 
         self.logbook('-> integrate_over_low_res_range ... DONE !')
 


### PR DESCRIPTION
`getIxyt` copies all the data out of the MantidWorkspace, constructing a 3-dimensional numpy array with dimensions like [303,256,472]. Only a subset of this data is then used, making the extraction a very wasteful and expensive procedure.

This branch refactors the use of this method to simply extract and calculate the explicitly required data, and removes the `getIxyt` method entirely.

On my machine this has significantly increased performance, the time required to load and process data being reduced by approximately a third.

The numbers I gathered from profiling (note, all are cumulative wall-clock times for that function, not per-call):

* runReduction
    * Before: 60.73
    * After: 40.50

The gain in speed comes from the following areas:

* from_event
    * Before: 42.59
    * After: 29.65
* rebin
    * Before: 24.80
    * After: 5.21
* integrate_over_low_res_range
    * Before: 0.08
    * After: 9.28

You'll note that because some of the calculations performed by `getIxyt` were still required, some of the processing time has simply been moved into `integrate_over_low_res_range`, however the time saved in `from_event` and `rebin` is still significant.