### PR TITLE
Update travis-ci script to trusty builder.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,46 +1,35 @@
+sudo: required
 language: python
-python:
-  - "2.7"
-  - "3.2"
+
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      python: 2.7
+    - os: linux
+      dist: trusty
+      python: 3.4
+
+virtualenv:
+  system_site_packages: true
+
 # whitelist
 branches:
   only:
     - master
+
 # command to install dependencies
-virtualenv:
-  system_site_packages: true
 before_install:
-  - 'if [ $TRAVIS_PYTHON_VERSION == "2.7" ]; then sudo apt-get update;sudo apt-get install python-numpy python-scipy python-matplotlib python-qt4 python-h5py; fi'
-  - 'if [ $TRAVIS_PYTHON_VERSION == "3.2" ]; then sudo apt-get update;sudo apt-get install python3-numpy python3-scipy python3-pyqt4 libhdf5-openmpi-dev; fi'
-#   - sudo apt-get install libhdf5-openmpi-dev
-#   - cd ..
-#   - wget http://sourceforge.net/projects/pyqt/files/sip/sip-4.14.5/sip-4.14.5.tar.gz
-#   - tar -xvf sip-4.14.5.tar.gz
-#   - cd sip-4.14.5
-#   - python configure.py
-#   - make -j 4
-#   - sudo make install
-#   - cd ..
-#   - wget http://sourceforge.net/projects/pyqt/files/PyQt4/PyQt-4.10/PyQt-x11-gpl-4.10.tar.gz
-#   - tar -xvf PyQt-x11-gpl-4.10.tar.gz
-#   - cd PyQt-x11-gpl-4.10
-#   - python configure.py --confirm-license
-#   - make -j 4
-#   - sudo make install
-#   - cd ../quicknxs
+  - sudo apt update
+  - if [ $TRAVIS_PYTHON_VERSION == "2.7" ]; then sudo apt install python-numpy python-scipy python-matplotlib python-qt4 python-h5py; fi
+  - if [ $TRAVIS_PYTHON_VERSION == "3.4" ]; then sudo apt install python3-numpy python3-scipy python3-matplotlib python3-pyqt4 python3-h5py; fi
 before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
 install: 
-#   - 'if [ $TRAVIS_PYTHON_VERSION == "3.2" ]; then pip install http://sourceforge.net/projects/pyparsing/files/pyparsing/pyparsing-1.5.7/pyparsing-1.5.7.tar.gz; fi'
-#   - "pip install numpy --use-mirrors"
-  - 'if [ $TRAVIS_PYTHON_VERSION == "3.2" ]; then export C_INCLUDE_PATH=/usr/lib/openmpi/include; fi'
-  - 'if [ $TRAVIS_PYTHON_VERSION == "3.2" ]; then pip install h5py --use-mirrors; fi'
-# #  - "pip install scipy --use-mirrors"
-  - 'if [ $TRAVIS_PYTHON_VERSION == "3.2" ]; then pip install matplotlib --use-mirrors; fi'
-  - 'if [ $TRAVIS_PYTHON_VERSION == "3.2" ]; then 2to3-3.2 -w scripts/quicknxs quicknxs tests test_all.py; fi'
+  - if [ $TRAVIS_PYTHON_VERSION == "3.4" ]; then 2to3-3.4 -w scripts/quicknxs quicknxs tests test_all.py; fi
 # command to run tests
 script: 
-  - 'if [ $TRAVIS_PYTHON_VERSION == "2.7" ]; then python -m unittest test_all; fi'
-  - 'if [ $TRAVIS_PYTHON_VERSION == "3.2" ]; then python -m unittest tests.qreduce_test tests.qcalc_test tests.qio_test; fi'
-  
+  - if [ $TRAVIS_PYTHON_VERSION == "2.7" ]; then python -m unittest test_all; fi
+  - if [ $TRAVIS_PYTHON_VERSION == "3.4" ]; then python -m unittest tests.qreduce_test tests.qcalc_test tests.qio_test; fi
+


### PR DESCRIPTION
The trusty image has system packages for all quicknxs dependencies and greatly simplifies our buildscript. I think it should also be closer to the RHEL 7 environment quicknxs is usually run on. 
